### PR TITLE
Add symbols to search

### DIFF
--- a/bend/src/python/controllers/Query.py
+++ b/bend/src/python/controllers/Query.py
@@ -2,23 +2,29 @@ from itertools import compress
 
 import pandas as pd
 
-combinators = {
-    "and": lambda a, b: a and b,
-    "or": lambda a, b: a or b
+from models.Artifact import ArtifactDict
+
+COMBINE_FILTERS_OPERATIONS = {
+    "&&": lambda a, b: a and b,
+    "||": lambda a, b: a or b
 }
 
-operations = {
-    "is": lambda a, b: a == b,
-    "contains": lambda a, b: b in a
+FILTER_OPERATIONS = {
+    "=": lambda a, b: a == b,
+    "!=": lambda a, b: a != b,
+    "~": lambda a, b: a in b,
+    "!~": lambda a, b: a not in b,
+    ">": lambda a, b: a > b,
+    "<": lambda a, b: a < b
 }
 
 
-def filter_artifacts(query: [str], artifacts):
+def filter_artifacts(query: [str], artifacts: [ArtifactDict]):
     mask = create_query_mask(query, artifacts)
     return list(compress(artifacts, mask))
 
 
-def create_query_mask(query: [str], artifacts, boolean_mask=None):
+def create_query_mask(query: [str], artifacts: [ArtifactDict], boolean_mask: [bool] = None) -> [bool]:
     """
     Creates the mask the applies the filter from the query
     """
@@ -27,32 +33,39 @@ def create_query_mask(query: [str], artifacts, boolean_mask=None):
 
     if len(query) == 0:
         return boolean_mask
-
     if len(query) < 3:
         raise Exception("Query must have attribute, operation, and value.")
-    # combining commands
+
     combinator = query[0].lower()
-    if combinator in combinators.keys():
-        if len(query) < 4:
-            raise Exception("combinator was given invalid right operand.")
+    if combinator not in COMBINE_FILTERS_OPERATIONS.keys():
+        return create_filter_mask(query, artifacts)
+    else:  # combinator is first item on recursive calls
+        return combine_filter_masks(query, combinator, artifacts, boolean_mask)
 
-        combinator_function = combinators[combinator]
-        next_mask = create_query_mask(query[1:4], artifacts)
-        next_boolean_mask = list(
-            map(combinator_function, boolean_mask, next_mask))
-        return create_query_mask(query[4:], artifacts, next_boolean_mask)
 
-    # single command
-    else:
-        attribute, operation, value = query[:3]
+def combine_filter_masks(query: str, combinator: str, artifacts: [ArtifactDict], boolean_mask: [bool]):
+    if len(query) < 4:
+        raise Exception("combinator was given invalid right operand.")
 
-        assert_artifact_contain_attribute(artifacts, attribute)
+    combinator_function = COMBINE_FILTERS_OPERATIONS[combinator]
+    next_mask = create_query_mask(query[1:4], artifacts)
+    next_boolean_mask = list(
+        map(combinator_function, boolean_mask, next_mask))
+    return create_query_mask(query[4:], artifacts, next_boolean_mask)
 
-        def operation_filter(artifact):
-            return operations[operation.lower()](
-                artifact[attribute].lower(), value.lower())
 
-        return create_query_mask(query[3:], artifacts, list(map(operation_filter, artifacts)))
+def create_filter_mask(query: str, artifacts: [ArtifactDict]):
+    attribute, operation, value = query[:3]
+    assert_artifact_contain_attribute(artifacts, attribute)
+
+    def operation_filter(artifact):
+        operation_label = operation.lower()
+        if operation_label not in FILTER_OPERATIONS.keys():
+            raise Exception("Unknown filter operation: %s" % operation_label)
+
+        return FILTER_OPERATIONS[operation.lower()](value.lower(), artifact[attribute].lower())
+
+    return create_query_mask(query[3:], artifacts, list(map(operation_filter, artifacts)))
 
 
 def assert_artifact_contain_attribute(artifacts, attribute: str):

--- a/bend/src/python/models/Artifact.py
+++ b/bend/src/python/models/Artifact.py
@@ -1,0 +1,6 @@
+from typing_extensions import TypedDict
+
+
+class ArtifactDict(TypedDict):
+    id: str
+    body: str

--- a/fend/src/shared/query/Types.ts
+++ b/fend/src/shared/query/Types.ts
@@ -4,12 +4,14 @@ export interface AttributeDefinition {
 }
 
 export const CATEGORICAL_OPERATIONS = [
-  "contains",
-  "does not contain",
-  "is",
-  "is not",
+  "~",
+  "!~",
+  "=",
+  "!=",
+  ">",
+  "<"
 ];
-export const COMBINATORS = ["and", "or"];
+export const COMBINATORS = ["&&", "||"];
 
 const TypeAttribute = {
   fieldName: "type",

--- a/fend/src/shared/types/Trace.ts
+++ b/fend/src/shared/types/Trace.ts
@@ -21,11 +21,22 @@ export interface WordDescriptor {
   relationshipIds: string[]
 }
 
+const SYN_NODE_TYPE = "SYNONYM"
+const SIB_NODE_TYPE = "SIBLING"
+const ANC_NODE_TYPE = "ANCESTOR"
+const CHILD_NODE_TYPE = "CHILD"
+const SOURCE_NODE_TYPE = "SOURCE"
+
 export type WordDescriptors = WordDescriptor[];
 
 export interface WordRelationshipNode {
   word: string
-  nodeType: "SIBLING" | "ANCESTOR" | "CHILD" | "SYNONYM" | "SOURCE"
+  nodeType:
+  typeof SIB_NODE_TYPE |
+  typeof ANC_NODE_TYPE |
+  typeof CHILD_NODE_TYPE |
+  typeof SYN_NODE_TYPE |
+  typeof SOURCE_NODE_TYPE
 }
 
 export type WordRelationshipNodes = WordRelationshipNode[];

--- a/fend/src/tests/QueryParser/IsValidQuery.test.ts
+++ b/fend/src/tests/QueryParser/IsValidQuery.test.ts
@@ -4,7 +4,7 @@ import {
   isValidCommandStep,
   isValidOperation,
   isValidQuery,
-  isValidValue,
+  isValidValue
 } from "../../shared/query/QueryValidator";
 
 /*
@@ -34,20 +34,20 @@ test("- : isValidAttibute : non attribute", () => {
  */
 
 test("+ : isValidOperation : categorical attribute", () => {
-  const operations = ["body", "contains"];
+  const operations = ["body", "~"];
   const [isValid, error] = isValidOperation(operations, 1);
   expect(isValid).toBe(true);
 });
 
 test("- : isValidOperation : no previous command", () => {
-  const operations = ["contains"];
+  const operations = ["~"];
   const [isValid, error] = isValidOperation(operations, 0);
   expect(isValid).toBe(false);
   expect(error.toLowerCase()).toContain("missing attribute");
 });
 
 test("- : isValidOperation : operation not found", () => {
-  const operations = ["body", "contains something like"];
+  const operations = ["body", "~ something like"];
   const [isValid, error] = isValidOperation(operations, 1);
   expect(isValid).toBe(false);
   expect(error.toLowerCase()).toContain("unknown operation");
@@ -82,13 +82,7 @@ test("- : isValidValue : contains quote", () => {
  */
 
 test("+ : isValidCombinator : default", () => {
-  const combinator = "or";
-  const [isValid, error] = isValidCombinator(combinator);
-  expect(isValid).toBe(true);
-});
-
-test("+ : isValidCombinator : default (case ignored)", () => {
-  const combinator = "AnD";
+  const combinator = "||";
   const [isValid, error] = isValidCombinator(combinator);
   expect(isValid).toBe(true);
 });
@@ -106,20 +100,20 @@ test("- : isValidCombinator : not a combinator", () => {
 
 test("- : isValidStep : index out of bounds", () => {
   expect(() =>
-    isValidCommandStep(['body contains "hello word"'], 2)
+    isValidCommandStep(['body ~ "hello word"'], 2)
   ).toThrowError("out-of-bounds");
 });
 
 test("+ : isValidStep : attribute", () => {
   const [isValid, error] = isValidCommandStep(
-    ["body", "contains", "state transitions"],
+    ["body", "~", "state transitions"],
     0
   );
   expect(isValid).toBe(true);
 });
 test("+ : isValidStep : operation", () => {
   const [isValid, error] = isValidCommandStep(
-    ["body", "contains", "state transitions"],
+    ["body", "~", "state transitions"],
     1
   );
   expect(isValid).toBe(true);
@@ -127,7 +121,7 @@ test("+ : isValidStep : operation", () => {
 
 test("+ : isValidStep : value", () => {
   const [isValid, error] = isValidCommandStep(
-    ["body", "contains", "state transitions"],
+    ["body", "~", "state transitions"],
     2
   );
   expect(isValid).toBe(true);
@@ -135,7 +129,7 @@ test("+ : isValidStep : value", () => {
 
 test("+ : isValidStep : combinator", () => {
   const [isValid, error] = isValidCommandStep(
-    ["body", "contains", "state transitions", "and"],
+    ["body", "~", "state transitions", "&&"],
     3
   );
   expect(isValid).toBe(true);
@@ -152,13 +146,13 @@ test("+ : isValidQuery : empty", () => {
 });
 
 test("+ : isValidQuery : empty", () => {
-  const query = "id is RE-8 or type is classes";
+  const query = "id = RE-8 || type = classes";
   const [isValid, error] = isValidQuery(query);
   expect(isValid).toBe(true);
 });
 
 test("- : isValidQuery : step parse error", () => {
-  const query = 'body contains "hello';
+  const query = 'body ~ "hello';
   const [isValid, error] = isValidQuery(query);
   expect(isValid).toBe(false);
   expect(error).toContain("closing quote");
@@ -172,13 +166,13 @@ test("- : isValidQuery : some step fails", () => {
 });
 
 test("- : isValidQuery : default", () => {
-  const query = 'body contains "hello"';
+  const query = 'body ~ "hello"';
   const [isValid, error] = isValidQuery(query);
   expect(isValid).toBe(true);
 });
 
 test("- : isValidQuery : missing value", () => {
-  const query = "body contains";
+  const query = "body ~";
   const [isValid, error] = isValidQuery(query);
   expect(isValid).toBe(false);
   expect(error.toLowerCase()).toContain("missing value");
@@ -192,7 +186,7 @@ test("- : isValidQuery : missing operation", () => {
 });
 
 test("- : isValidQuery : missing combinator right term", () => {
-  const query = 'body contains "hello" and';
+  const query = 'body ~ "hello" and';
   const [isValid, error] = isValidQuery(query);
   expect(isValid).toBe(false);
   expect(error.toLowerCase()).toContain("combinator");

--- a/fend/src/tests/QueryParser/QueryStepParser.test.ts
+++ b/fend/src/tests/QueryParser/QueryStepParser.test.ts
@@ -9,35 +9,35 @@ test("+ : getStepsInQuery : empty : default", () => {
 });
 
 test("+ : getStepsInQuery : value : multiple", () => {
-  const query = 'body contains "hello world"';
+  const query = 'body ~ "hello world"';
   const steps = getStepsInQuery(query);
   expect(steps.length).toBe(3);
   expect(steps[0]).toBe("body");
-  expect(steps[1]).toBe("contains");
+  expect(steps[1]).toBe("~");
   expect(steps[2]).toBe("hello world");
 });
 test("+ : getStepsInQuery : value : single", () => {
-  const query = 'id is "RE-8"';
+  const query = 'id = "RE-8"';
   const steps = getStepsInQuery(query);
   expect(steps.length).toBe(3);
   expect(steps[0]).toBe("id");
-  expect(steps[1]).toBe("is");
+  expect(steps[1]).toBe("=");
   expect(steps[2]).toBe("RE-8");
 });
 
 test("- : getStepsInQuery : too little quotes : single", () => {
-  const query = 'id is "RE-8';
+  const query = 'id = "RE-8';
   expect(() => getStepsInQuery(query)).toThrowError("closing quote");
 });
 test("- : getStepsInQuery : too little quote : multi", () => {
-  const query = 'id is "RE-8 a cool requirement';
+  const query = 'id = "RE-8 a cool requirement';
   expect(() => getStepsInQuery(query)).toThrowError("closing quote");
 });
 test("- : getStepsInQuery : too many quotes : single", () => {
-  const query = 'id is "RE-8""';
+  const query = 'id = "RE-8""';
   expect(() => getStepsInQuery(query)).toThrowError("Too many quotes");
 });
 test("- : getStepsInQuery : too many quotes : multi", () => {
-  const query = 'id is "RE-8 nope""';
+  const query = 'id = "RE-8 nope""';
   expect(() => getStepsInQuery(query)).toThrowError("Too many quotes");
 });

--- a/fend/src/tests/QueryParser/Recommendations.test.ts
+++ b/fend/src/tests/QueryParser/Recommendations.test.ts
@@ -1,8 +1,5 @@
 import { getQueryRecommendations } from "../../shared/query/QueryRecommender";
-import {
-  ATTRIBUTE_VALUES,
-  CATEGORICAL_OPERATIONS,
-} from "../../shared/query/QueryValidator";
+import { ATTRIBUTE_VALUES, CATEGORICAL_OPERATIONS } from "../../shared/query/Types";
 
 test("+ : getRecommendations : attributes", () => {
   const query = "";

--- a/fend/src/tests/WordCreator/WordCreator.test.ts
+++ b/fend/src/tests/WordCreator/WordCreator.test.ts
@@ -1,15 +1,13 @@
 import {
   createDefaultWordDescriptors,
-  KeyWordType,
-  splitWordsByDelimiter,
-  SyntaxWordType
+  splitWordsByDelimiter
 } from "../../shared/artifacts/WordCreator";
-import { WordDescriptor } from "../../shared/types/Trace";
+import { KeyWordType, SyntaxWordType, WordDescriptor } from "../../shared/types/Trace";
 
 test("dummy test", () => {
   const document = "function(int count)";
   const documentWords = ["function", "(", "int", " ", "count", ")"];
-  const requiredFamilies = [SyntaxWordType, KeyWordType, ""];
+  const requiredFamilies = [SyntaxWordType, KeyWordType];
 
   //Body
   const words: WordDescriptor[] = createDefaultWordDescriptors(document);
@@ -21,8 +19,8 @@ test("dummy test", () => {
 
     expect(word.word).not.toStrictEqual("");
     expect(documentWords).toContain(word.word);
-    for (let wordFamilyIndex in word.families)
-      familiesInWords.push(word.families[wordFamilyIndex]);
+    for (let wordFamilyIndex in word.relationshipIds)
+      familiesInWords.push(word.relationshipIds[wordFamilyIndex]);
   }
 
   for (let requiredFamilyIndex in requiredFamilies) {


### PR DESCRIPTION
filters for queries were using natural language words like "contains" or "does not contain". In this pull request they are replaced with symbols like "~" and "!~", respectively.