### PR TITLE
Refactoring / Enabled word colors again

### DIFF
--- a/fend/src/components/artifacts/ArtifactDisplayFactory.tsx
+++ b/fend/src/components/artifacts/ArtifactDisplayFactory.tsx
@@ -2,12 +2,8 @@ import React from "react";
 import { createDefaultWordDescriptors, getDefaultFamilies, getDefaultFamilyColors } from "../../shared/artifacts/WordCreator";
 import { Artifact, ArtifactIdentifier } from "../../shared/types/Dataset";
 import { FamilyColors, Relationships, WordDescriptors } from "../../shared/types/Trace";
+import { colors } from "../constants";
 import ArtifactAccordion from "./accordion/ArtifactAccordion";
-
-
-export const colors = ["CornFlowerBlue", "DarkSeaGreen", "DarkSalmon", "Khaki", "BlueViolet", "FireBrick", "LightGreen", "Maroon",
-  "DeepSkyBlue", "MediumOrchid", "Olive", "SpringGreen"]; //TODO: Add to theme
-
 
 export function getDefaultArtifactDisplay(
   artifact: ArtifactIdentifier,
@@ -62,28 +58,31 @@ export function createTraceArtifactDisplays(
   traceWords: WordDescriptors,
   familyColors: Record<string, string>,
   setIndex: (index: number) => void) {
-  return <div className="heightFull overflowScroll">
-    {artifacts.map((artifact, index) => {
-      if (index === selectedIndex) {
-        return getTraceArtifactDisplay(
-          traceWords,
-          families,
-          artifact,
-          familyColors,
-          true,
-          () => setIndex(index),
-          () => setIndex(-1)
-        );
-      } else {
-        return getDefaultArtifactDisplay(
-          artifact,
-          createDefaultWordDescriptors(artifact.body),
-          false,
-          () => setIndex(index),
-          () => setIndex(-1)
-        );
-      }
-    })}</div>;
+  return (
+    <div className="heightFull overflowScroll"> {
+      artifacts.map((artifact, index) => {
+        if (index === selectedIndex) {
+          return getTraceArtifactDisplay(
+            traceWords,
+            families,
+            artifact,
+            familyColors,
+            true,
+            () => setIndex(index),
+            () => setIndex(-1)
+          );
+        } else {
+          return getDefaultArtifactDisplay(
+            artifact,
+            createDefaultWordDescriptors(artifact.body),
+            false,
+            () => setIndex(index),
+            () => setIndex(-1)
+          );
+        }
+      })
+    }
+    </div>);
 }
 
 /*

--- a/fend/src/components/artifacts/Artifacts.tsx
+++ b/fend/src/components/artifacts/Artifacts.tsx
@@ -46,6 +46,8 @@ export default function ArtifactSelector() {
 
   const dispatch = useDispatch()
 
+  console.log(traceFamilyColors)
+
   useEffect(() => {
     if (currentStep === SELECT_SOURCE_STEP) {
       setLeftPanel(<SourceArtifactSearch />);
@@ -105,7 +107,11 @@ export default function ArtifactSelector() {
       setLoading(true)
       getTraceInformation(dataset.name, sourceArtifact, targetArtifact) // change with state index
         .then((traceInformation) => {
-          const familyColors = createFamilyColors(Object.keys(traceInformation.relationships));
+          console.log(traceInformation.relationships)
+          const familyColors = createFamilyColors(
+            traceInformation
+              .relationships
+              .map(relationship => relationship.title));
           setTraceFamilyColors(familyColors)
           setSourceWords(traceInformation.sourceDescriptors)
           setTargetWords(traceInformation.targetDescriptors)

--- a/fend/src/components/artifacts/accordion/ArtifactAccordion.tsx
+++ b/fend/src/components/artifacts/accordion/ArtifactAccordion.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { createWords } from "../../../shared/artifacts/WordCreator";
 import { FamilyColors, Relationships, WordDescriptorDisplay, WordDescriptors, Words } from "../../../shared/types/Trace";
 import { primaryColor } from "../../../styles/theme";
+import { DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE, FONT_SIZE_DELTA } from "../../constants";
 import ArtifactAccordionDetails from "./ArtifactAccordionDetails";
 import ArtifactAccordionSummary from "./ArtifactAccordionSummary";
 import { createToolbarIcons } from "./ToolbarIcons";
@@ -11,13 +12,7 @@ import { createToolbarIcons } from "./ToolbarIcons";
 /*
  * Accordion for TraceInformation. Manages state changes in accordion.
  */
-
-export const DEFAULT_FONT_COLOR = "black";
-const FONT_SIZE_DELTA = 0.2;
 const ACCORDION_MAX_HEIGHT = 500 //px
-const DEFAULT_FONT_SIZE = 1;
-const SIZE_SELECTED_DEFAULT_VALUE = true;
-const COLOR_SELECTED_DEFAULT_VALUE = true;
 
 interface ArtifactAccordionProps {
   artifactType: string;
@@ -31,8 +26,8 @@ interface ArtifactAccordionProps {
 }
 
 export default function ArtifactAccordion(props: ArtifactAccordionProps) {
-  const [sizeSelected, setSizeSelected] = useState(SIZE_SELECTED_DEFAULT_VALUE);
-  const [colorSelected, setColorSelected] = useState(COLOR_SELECTED_DEFAULT_VALUE);
+  const [sizeSelected, setSizeSelected] = useState(true);
+  const [colorSelected, setColorSelected] = useState(true);
   const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE);
   const [selectedWord, setSelectedWord] = useState<WordDescriptorDisplay | null>(null)
 

--- a/fend/src/components/artifacts/accordion/words/Word.tsx
+++ b/fend/src/components/artifacts/accordion/words/Word.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { WordDescriptorDisplay } from "../../../../shared/types/Trace";
-import { DEFAULT_FONT_COLOR } from "../ArtifactAccordion";
+import { DEFAULT_FONT_COLOR } from "../../../constants";
 import { WordCallback } from "./ArtifactAccordionWords";
 
 export interface WordProps {

--- a/fend/src/components/constants.ts
+++ b/fend/src/components/constants.ts
@@ -1,0 +1,7 @@
+export const colors = [
+  "CornFlowerBlue", "DarkSeaGreen", "DarkSalmon", "BlueViolet", "FireBrick", "LightGreen",
+  "Maroon", "DeepSkyBlue", "MediumOrchid", "Olive", "SpringGreen"]; //TODO: Add to theme
+
+export const DEFAULT_FONT_COLOR = "black";
+export const DEFAULT_FONT_SIZE = 1;
+export const FONT_SIZE_DELTA = 0.2;

--- a/fend/src/components/search/bar/BasicSearchBar.tsx
+++ b/fend/src/components/search/bar/BasicSearchBar.tsx
@@ -3,6 +3,9 @@ import { CATEGORICAL_OPERATIONS } from "../../../shared/query/Types";
 import QueryFilterElement from "./QueryFilterElement";
 import { SubmitFuncType } from './SearchBar';
 
+export type REACT_STRING_SETTER = React.Dispatch<React.SetStateAction<string>>
+const EMPTY_QUERY = ""
+
 interface BasicSearchBarProps {
   query: string
   setQuery: SubmitFuncType
@@ -12,9 +15,6 @@ interface BasicSearchBarProps {
   onChangeMode: () => void
 }
 
-const EMPTY_QUERY = ""
-export type REACT_STRING_SETTER = React.Dispatch<React.SetStateAction<string>>
-
 export default function BasicSearchBar(props: BasicSearchBarProps) {
   const [idFilter, setIdFilter] = useState("=")
   const [idQuery, setIdQuery] = useState(EMPTY_QUERY)
@@ -23,7 +23,7 @@ export default function BasicSearchBar(props: BasicSearchBarProps) {
   const [typeFilter, setTypeFilter] = useState("=")
   const [typeQuery, setTypeQuery] = useState(EMPTY_QUERY)
 
-  const { setQuery, onSearch, onChangeMode } = props
+  const { setQuery, onSearch } = props
 
   const createQuery = (): string => {
     const queries = [["id", idFilter, idQuery], ["body", bodyFilter, bodyQuery], ["type", typeFilter, typeQuery]]
@@ -53,7 +53,7 @@ export default function BasicSearchBar(props: BasicSearchBarProps) {
         setFilter={setIdFilter}
         query={idQuery}
         setQuery={createQuerySetter(setIdQuery)}
-        onSearch={props.onSearch}
+        onSearch={onSearch}
       />
       <QueryFilterElement
         label={"body"}
@@ -62,7 +62,7 @@ export default function BasicSearchBar(props: BasicSearchBarProps) {
         setFilter={setBodyFilter}
         query={bodyQuery}
         setQuery={createQuerySetter(setBodyQuery)}
-        onSearch={props.onSearch}
+        onSearch={onSearch}
       />
       <QueryFilterElement
         label={"type"}
@@ -71,7 +71,7 @@ export default function BasicSearchBar(props: BasicSearchBarProps) {
         setFilter={setTypeFilter}
         query={typeQuery}
         setQuery={createQuerySetter(setTypeQuery)}
-        onSearch={props.onSearch}
+        onSearch={onSearch}
       />
     </div>)
 }

--- a/fend/src/shared/artifacts/WordCreator.ts
+++ b/fend/src/shared/artifacts/WordCreator.ts
@@ -2,12 +2,8 @@ import { Artifact, ArtifactDisplayModel } from "../types/Dataset";
 import {
   FamilyColors,
   KeyWordType, Relationships,
-
-
   SyntaxWordType,
-
   WordDescriptor, WordDescriptorDisplay,
-
   WordDescriptors,
   Words
 } from "../types/Trace";
@@ -148,6 +144,7 @@ export function createWord(
       mainFamilyId in familyColors
         ? familyColors[mainFamilyId]
         : defaultColor;
+
   } else {
     wordSize = defaultSize
     wordColor = defaultColor


### PR DESCRIPTION
Colors were never disabled, but bug arose that mismatched attached color to word in WordCreator. The ids had to be mapped out of an object instead.